### PR TITLE
Fix overflowing of logo playground

### DIFF
--- a/_sass/_main.scss
+++ b/_sass/_main.scss
@@ -325,22 +325,47 @@ a {
     }
 }
 
-.socials{
+.socials {
     font-size: 2em;
 }
 
-.logo-playground-container {
-    display: flex;
-    justify-content: center;
-    width: 100%;
+.desktop-visible {
+    display: none;
+}
 
-    .logo-playground-border {
-        border: solid 2px $text;
-    }
+.desktop-invisible {
+    display: initial;
+}
+
+.logo-playground-container {
+    border: solid 2px $text;
 }
 
 .logo-playground {
-    padding: 200px;
-    background-color: $c-blue-dark;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+    padding: 10px;
+    width: 100%;
+    height: 100%;
+}
+
+.logo-playground-text {
     font-size: 40pt;
 }
+
+@media #{$breakpoint-desktop} {
+    .logo-playground {
+        min-height: 480px;
+    }
+
+    .desktop-visible {
+        display: initial;
+    }
+
+    .desktop-invisible {
+        display: none;
+    }
+}
+

--- a/design.html
+++ b/design.html
@@ -37,8 +37,7 @@ id: design
         <div class="box">
             <h3>Playground</h3>
             
-            <p class="desktop-visible">Use browser inspect to create what you need, then capture node screenshot on <span class="monospace">.logo-playground</span> element.</p>
-            
+            <p class="desktop-visible">Edit the logo as you need (directly in the box) and then capture screenshot using your OS or browser inspect and capture node screenshot feature on <span class="monospace">.logo-playground</span> element.</p>
             <p class="desktop-invisible">I am pretty sure this device is too small to have inspect mode. So no play time for you. &#129398</p>
             <div class="logo-playground-container">
                 <div class="logo-playground">

--- a/design.html
+++ b/design.html
@@ -36,13 +36,17 @@ id: design
     <div class="col-md-8 offset-md-2">
         <div class="box">
             <h3>Playground</h3>
-            <p>Use browser inspect to create what you need, then capture node screenshot on <span class="monospace">.logo-playground</span> element.</p>
+            
+            <p class="desktop-visible">Use browser inspect to create what you need, then capture node screenshot on <span class="monospace">.logo-playground</span> element.</p>
+            
+            <p class="desktop-invisible">I am pretty sure this device is too small to have inspect mode. So no play time for you. &#129398</p>
             <div class="logo-playground-container">
-                <div class="logo-playground-border">
-                    <div class="logo-playground">
-                        <div class="logo">
-                            <span class="monospace">garage::<span class="secondary-color">&#10033;</span></span>
-                        </div>
+                <div class="logo-playground">
+                    <div class="logo logo-playground-text desktop-visible" contenteditable="true">
+                        <span class="monospace">garage::<span class="secondary-color">&#10033;</span></span>
+                    </div>
+                    <div class="logo logo-playground-text desktop-invisible">
+                        <span class="monospace">garage::<span class="secondary-color">&#10033;</span></span>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
**Problem**
![Problem](https://github.com/user-attachments/assets/c65d5280-3b71-43e1-8ee4-a94208a5abda)

**Solution**
![Solution](https://github.com/user-attachments/assets/2afd9199-57d1-46d1-98fd-8ba9afa2e884)


**additional**
- added sad text on mobile devices
- added content [editable property](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/contenteditable) on logo element, so now you can edit text in browser without inspect 